### PR TITLE
Fix rs webpack

### DIFF
--- a/packages/circus-rs/package.json
+++ b/packages/circus-rs/package.json
@@ -4,7 +4,7 @@
   "scripts": {
     "start": "node ./server.js",
     "debug": "nodemon --inspect ./server.js",
-    "devserver": "webpack-dev-server",
+    "devserver": "webpack serve --mode=development",
     "build": "webpack --mode=production",
     "watch": "webpack --watch",
     "build-npm": "tsc && cp src/browser/image-source/volume-rendering-image-source/*.{vert,frag} lib/browser/image-source/volume-rendering-image-source",

--- a/packages/circus-rs/webpack.config.js
+++ b/packages/circus-rs/webpack.config.js
@@ -37,7 +37,8 @@ module.exports = (env, argv) => ({
   ],
   devServer: {
     contentBase: path.join(__dirname, 'demo'),
-    disableHostCheck: true
+    disableHostCheck: true,
+    injectClient: false
   },
   ...(argv.mode !== 'production' ? { devtool: 'source-map' } : {}),
   cache: {


### PR DESCRIPTION
rs で webpack5 を使用できるようにする。
umd と hot reload の相性が悪い？らしく、hot reload を無効にすることで対応。