### PR TITLE
Fix RS webpack config to resolve issues with woff embedding

### DIFF
--- a/packages/circus-rs/webpack.config.js
+++ b/packages/circus-rs/webpack.config.js
@@ -24,7 +24,7 @@ module.exports = (env, argv) => ({
       },
       { test: /\.less$/, use: ['style-loader', 'css-loader', 'less-loader'] },
       { test: /\.css$/, use: ['style-loader', 'css-loader'] },
-      { test: /\.woff$/, use: ['url-loader'] },
+      { test: /\.woff$/, type: 'asset/inline' },
       { test: /\.frag|\.vert$/, use: ['webpack-glsl-loader'] }
     ]
   },


### PR DESCRIPTION
This fix resolves a bug that prevented the icon from being displayed when starting RS devserver.