### PR TITLE
Add an endpoint to upload one DICOM file without generating a task

### DIFF
--- a/packages/circus-api/src/api/series/index.ts
+++ b/packages/circus-api/src/api/series/index.ts
@@ -158,10 +158,18 @@ export const handlePostSingle: RouteMiddleware = ({ dicomImporter }) => {
     if (!isLikeDicom(arrayBuffer)) {
       ctx.throw(
         status.BAD_REQUEST,
-        'The file is not a DICOM file. You cannot use archive files.'
+        'The file is not a DICOM file. You cannot use archived files.'
       );
     }
-    await dicomImporter.importDicom(arrayBuffer, domain);
+    try {
+      await dicomImporter.importDicom(arrayBuffer, domain);
+    } catch (err: any) {
+      ctx.throw(
+        status.INTERNAL_SERVER_ERROR,
+        'Error while importing a DICOM file. ' +
+          'This may mean the uploaded file is broken.'
+      );
+    }
     ctx.body = null;
     ctx.status = status.CREATED; // 201
   };

--- a/packages/circus-api/src/api/series/index.yaml
+++ b/packages/circus-api/src/api/series/index.yaml
@@ -17,7 +17,12 @@ routes:
   - verb: post
     path: /series/domain/:domain
     expectedContentType: multipart/form-data
-    description: Uploads one or more DICOM files.
+    description: Uploads one or more DICOM files, creating a task.
+  - verb: post
+    path: /series/domain/:domain/single
+    expectedContentType: multipart/form-data
+    handler: handlePostSingle
+    description: Uploads one DICOM file without creating a task.
   - verb: get
     path: /series/:seriesUid
     description: Returns information about the specified series.


### PR DESCRIPTION
Fixes #300

The endpoint is: `PUSH /api/series/${domain}/single`.