### PR TITLE
Add keyboard shortcuts for brush/eraser size control and paging

### DIFF
--- a/packages/circus-web-ui/src/components/ImageViewer.tsx
+++ b/packages/circus-web-ui/src/components/ImageViewer.tsx
@@ -196,6 +196,28 @@ const ImageViewer: React.FC<{
     viewer.setActiveTool(tool);
   }, [viewer, tool]);
 
+  // Handle keydown to simulate wheel event
+  useEffect(() => {
+    const container = containerRef.current!;
+    const onKeydown = (e: KeyboardEvent) => {
+      const parent = container.closest('.grid-container-cell');
+      const canvas = container.querySelector('canvas');
+      if (canvas && parent && parent.querySelector('.active')) {
+        if (e.key === 'ArrowLeft') {
+          const wheelEvent = new WheelEvent('wheel', { deltaY: 1 });
+          canvas.dispatchEvent(wheelEvent);
+        } else if (e.key === 'ArrowRight') {
+          const wheelEvent = new WheelEvent('wheel', { deltaY: -1 });
+          canvas.dispatchEvent(wheelEvent);
+        }
+      }
+    };
+    window.addEventListener('keydown', onKeydown);
+    return () => {
+      window.removeEventListener('keydown', onKeydown);
+    };
+  }, []);
+
   return (
     <div className={classnames('image-viewer', className)} ref={containerRef} />
   );

--- a/packages/circus-web-ui/src/components/ImageViewer.tsx
+++ b/packages/circus-web-ui/src/components/ImageViewer.tsx
@@ -95,6 +95,7 @@ const ImageViewer: React.FC<{
   onDestroyViewer?: (viewer: rs.Viewer) => void;
   onViewStateChange?: (viewer: rs.Viewer, id?: string | number) => void;
   onMouseUp?: () => void;
+  activeKeydown?: boolean;
 }> = props => {
   const {
     className,
@@ -106,7 +107,8 @@ const ImageViewer: React.FC<{
     onCreateViewer = noop,
     onDestroyViewer = noop,
     onViewStateChange = noop,
-    onMouseUp = noop
+    onMouseUp = noop,
+    activeKeydown = false
   } = props;
 
   const [viewer, setViewer] = useState<rs.Viewer | null>(null);
@@ -199,24 +201,23 @@ const ImageViewer: React.FC<{
   // Handle keydown to simulate wheel event
   useEffect(() => {
     const container = containerRef.current!;
-    const onKeydown = (e: KeyboardEvent) => {
-      const parent = container.closest('.grid-container-cell');
+    const handleKeydown = (e: KeyboardEvent) => {
       const canvas = container.querySelector('canvas');
-      if (canvas && parent && parent.querySelector('.active')) {
-        if (e.key === 'ArrowLeft') {
+      if (canvas && activeKeydown) {
+        if (e.key === 'ArrowLeft' || e.key === 'ArrowUp') {
           const wheelEvent = new WheelEvent('wheel', { deltaY: 1 });
           canvas.dispatchEvent(wheelEvent);
-        } else if (e.key === 'ArrowRight') {
+        } else if (e.key === 'ArrowRight' || e.key === 'ArrowDown') {
           const wheelEvent = new WheelEvent('wheel', { deltaY: -1 });
           canvas.dispatchEvent(wheelEvent);
         }
       }
     };
-    window.addEventListener('keydown', onKeydown);
+    window.addEventListener('keydown', handleKeydown);
     return () => {
-      window.removeEventListener('keydown', onKeydown);
+      window.removeEventListener('keydown', handleKeydown);
     };
-  }, []);
+  }, [activeKeydown]);
 
   return (
     <div className={classnames('image-viewer', className)} ref={containerRef} />

--- a/packages/circus-web-ui/src/pages/case-detail/ToolBar.tsx
+++ b/packages/circus-web-ui/src/pages/case-detail/ToolBar.tsx
@@ -330,7 +330,11 @@ const ToolBar: React.FC<{
               </MenuItem>
             );
           })}
-          <MenuItem header>Q: Wider, A: Narrower</MenuItem>
+          <MenuItem header>
+            <ShortcutBox>
+              <kbd>Q</kbd>: Wider,&nbsp;<kbd>A</kbd>: Narrower
+            </ShortcutBox>
+          </MenuItem>
         </Dropdown.Menu>
       </Dropdown>
       <ToolButton

--- a/packages/circus-web-ui/src/pages/case-detail/ToolBar.tsx
+++ b/packages/circus-web-ui/src/pages/case-detail/ToolBar.tsx
@@ -80,25 +80,25 @@ const layoutOptions: {
     key: 'twoByTwo',
     caption: '2 x 2',
     icon: 'circus-layout-four',
-    shortcut: 'X'
+    shortcut: 'Shift+X'
   },
   {
     key: 'axial',
     caption: 'Axial',
     icon: 'circus-orientation-axial',
-    shortcut: 'A'
+    shortcut: 'Shift+A'
   },
   {
     key: 'sagittal',
     caption: 'Sagittal',
     icon: 'circus-orientation-sagittal',
-    shortcut: 'S'
+    shortcut: 'Shift+S'
   },
   {
     key: 'coronal',
     caption: 'Coronal',
     icon: 'circus-orientation-coronal',
-    shortcut: 'C'
+    shortcut: 'Shift+C'
   }
 ];
 
@@ -165,6 +165,18 @@ const ToolBar: React.FC<{
     { label: 'x1/4', level: 0.25 },
     { label: 'x1/8', level: 0.125 }
   ];
+
+  const handleLineWidth = (widen: boolean) => () => {
+    if (!brushEnabled || disabled) return;
+    const pos = widthOptions.findIndex(
+      lineWidth => lineWidth === String(toolOptions.lineWidth)
+    );
+    if ((!widen && pos < 1) || (widen && widthOptions.length - 1 <= pos))
+      return;
+    setToolOption('lineWidth', Number(widthOptions[widen ? pos + 1 : pos - 1]));
+  };
+  useKeyboardShortcut('Q', handleLineWidth(true));
+  useKeyboardShortcut('A', handleLineWidth(false));
 
   const handleToggleReferenceLine = () => {
     onChangeViewOptions({
@@ -300,14 +312,27 @@ const ToolBar: React.FC<{
         shortcut="E"
         disabled={!brushEnabled || disabled}
       />
-      <ShrinkSelect
-        numericalValue
+      <Dropdown
+        id="line-width-dropdown"
         className="line-width-shrinkselect"
-        options={widthOptions}
-        value={toolOptions.lineWidth}
-        onChange={lineWidth => setToolOption('lineWidth', lineWidth)}
         disabled={!brushEnabled || disabled}
-      />
+      >
+        <Dropdown.Toggle>{toolOptions.lineWidth}</Dropdown.Toggle>
+        <Dropdown.Menu>
+          {widthOptions.map(lineWidth => {
+            return (
+              <MenuItem
+                key={lineWidth}
+                eventKey={lineWidth}
+                onSelect={lineWidth => setToolOption('lineWidth', lineWidth)}
+              >
+                {lineWidth}
+              </MenuItem>
+            );
+          })}
+          <MenuItem header>Q: Wider, A: Narrower</MenuItem>
+        </Dropdown.Menu>
+      </Dropdown>
       <ToolButton
         name="bucket"
         icon="rs-bucket"

--- a/packages/circus-web-ui/src/pages/case-detail/ViewerGrid.tsx
+++ b/packages/circus-web-ui/src/pages/case-detail/ViewerGrid.tsx
@@ -242,10 +242,13 @@ const Content: React.FC<{ value: ViewerDef }> = props => {
     initialStateSetter,
     onCreateViewer,
     onDestroyViewer,
-    onViewStateChange
+    onViewStateChange,
+    editingData
   } = useContext(ViewerGridContext)!;
 
   const composition = compositions[seriesIndex].composition;
+  const { activeLayoutKey } = editingData;
+  const active = key === activeLayoutKey;
 
   const combinedInitialStateSetter = useCallback(
     (viewer: Viewer, viewState: MprViewState | TwoDimensionalViewState) => {
@@ -254,8 +257,8 @@ const Content: React.FC<{ value: ViewerDef }> = props => {
           const initialState = getInitial2dViewState(viewer, viewState)!;
           const s1 = initialSection
             ? {
-              ...sectionTo2dViewState(initialState, initialSection)
-            }
+                ...sectionTo2dViewState(initialState, initialSection)
+              }
             : initialState;
           const s2 = initialStateSetter(viewer, s1, key);
           return s2;
@@ -267,8 +270,9 @@ const Content: React.FC<{ value: ViewerDef }> = props => {
           )!;
           const s1 = initialSection
             ? {
-              ...initialState, section: initialSection
-            }
+                ...initialState,
+                section: initialSection
+              }
             : initialState;
           const s2 = initialStateSetter(viewer, s1, key);
           return s2;
@@ -325,6 +329,7 @@ const Content: React.FC<{ value: ViewerDef }> = props => {
       onCreateViewer={onCreateViewer}
       onDestroyViewer={onDestroyViewer}
       onViewStateChange={onViewStateChange}
+      activeKeydown={active}
     />
   );
 };


### PR DESCRIPTION
This PR does the following:

- Add shortcut to increase/decrease the brush size (<kbd>Q</kbd>, <kbd>A</kbd>)
- Add keyboard navigation to page images (<kbd>Down</kbd>, etc)
- Change keyboard shortcut to change layout from <kbd>A</kbd> to <kbd>Shift+A</kbd>, etc