### PR TITLE
Add doodHostWorkingPath option

### DIFF
--- a/packages/circus-cs-core/src/config/default.ts
+++ b/packages/circus-cs-core/src/config/default.ts
@@ -14,6 +14,7 @@ const defaults: circus.Configuration = {
   jobRunner: {
     options: {
       workingDirectory: path.join(os.tmpdir(), 'circus-cs'),
+      doodHostWorkingDirectory: undefined,
       removeTemporaryDirectory: true
     }
   },


### PR DESCRIPTION
This adds a new `doodHostWorkingDirectory` option to `pluginJobRunner`.

When using CIRCUS with the DooD (docker-outside-of-docker) approach, the main CIRCUS container and a plug-in container will be created like this:

```
Host --------------------------------------> CIRCUS
       -v c:\circus-data:/var/circus/data

Host -----------------------------------------------> Plugin (eg MRA-CAD)
       -v c:\circus-data\cs-tmp\dd6b343:/circus/in
          ^^^^^^^^^^^^^^^^^^^^^
```

CIRCUS running in a container must ask the host to create the plug-in container, but it does not know the path of the parent host directory (i.e., "c:\circus-data\cs-tmp\"). This option is used to set this path. The path must correspond to the `workingDirectory` option.