### PR TITLE
Fix persistent disabled-button tooltip

### DIFF
--- a/packages/circus-ui-kit/src/cs/displays/Choice.tsx
+++ b/packages/circus-ui-kit/src/cs/displays/Choice.tsx
@@ -148,6 +148,7 @@ const ToggleButtons: ChoiceUI = props => {
               color={choice.color}
               selected={choice.value === selected}
               className="button-with-tooltip"
+              style={disabled ? { pointerEvents: 'none' } : {}}
             >
               <span className="opinions">
                 {opinions?.get(choice.value)?.length}

--- a/packages/circus-ui-kit/src/ui/Button.tsx
+++ b/packages/circus-ui-kit/src/ui/Button.tsx
@@ -22,6 +22,7 @@ export const Button: React.FC<{
   className?: string;
   selected?: boolean;
   disabled?: boolean;
+  style?: React.CSSProperties;
   onClick?: React.MouseEventHandler;
 }> = forwardRef((props, ref) => {
   const {
@@ -31,6 +32,7 @@ export const Button: React.FC<{
     className,
     selected,
     disabled,
+    style,
     onClick,
     children
   } = props;
@@ -48,6 +50,7 @@ export const Button: React.FC<{
       size={size}
       onClick={onClick}
       disabled={disabled}
+      style={style}
       className={classNames(className, { selected })}
     >
       {icon && <span className={iconClass} />}


### PR DESCRIPTION
Fixed a bug that a Tooltip did not disappear because onMouseLeave was not fired by a disabled button.