### PR TITLE
Modify sliceCount for width*height > 512*512

### DIFF
--- a/packages/circus-rs/src/browser/image-source/gl/MprProgram.ts
+++ b/packages/circus-rs/src/browser/image-source/gl/MprProgram.ts
@@ -23,7 +23,7 @@ import {
 } from './glsl/mprShaderSource';
 
 const maxTextures = 8;
-const maxSliceCount = 1024;
+const maxCount = 512 * 512 * 1024;
 
 export default class MprProgram extends ShaderProgram {
   /**
@@ -120,6 +120,7 @@ export default class MprProgram extends ShaderProgram {
     ]);
     this.uVolumeDimension(dimension);
 
+    const maxSliceCount = maxCount / (dimension[0] * dimension[1]);
     const numTextures = Math.ceil(dimension[2] / maxSliceCount);
     this.uMaxSliceCount(maxSliceCount);
     this.volumeTextures = [...Array(numTextures)].map(() =>

--- a/packages/circus-rs/src/browser/image-source/gl/texture/volumeTextureTransferer.ts
+++ b/packages/circus-rs/src/browser/image-source/gl/texture/volumeTextureTransferer.ts
@@ -12,7 +12,7 @@ export default function volumeTextureTransferer(
   const { sliceSize, sliceGridSize, textureSize } = detectTextureLayout([
     voxelCount[0],
     voxelCount[1],
-    maxSliceCount
+    Math.min(maxSliceCount, voxelCount[2])
   ]);
 
   const getOriginOfSlice = (z: number) => [


### PR DESCRIPTION
WebGlTextureのスライス枚数が1024に固定されていたバグを修正しました。