### PR TITLE
Modify parameters for 2D and partial 3D images

### DIFF
--- a/packages/circus-rs/src/browser/image-source/TwoDimensionalImageSource.ts
+++ b/packages/circus-rs/src/browser/image-source/TwoDimensionalImageSource.ts
@@ -235,6 +235,7 @@ export default class TwoDimensionalImageSource extends ImageSource {
     image: ImageBitmap
   ): ImageData {
     const outSize = viewer.getResolution();
+    const pixelSpacing = this.metadata?.voxelSize ?? [1, 1, 1];
     this.backCanvas.width = outSize[0];
     this.backCanvas.height = outSize[1];
 
@@ -246,8 +247,8 @@ export default class TwoDimensionalImageSource extends ImageSource {
 
     const sx = origin[0];
     const sy = origin[1];
-    const sw = xAxis[0];
-    const sh = yLength;
+    const sw = xAxis[0] / pixelSpacing[0];
+    const sh = yLength / pixelSpacing[1];
     const dx = 0;
     const dy = 0;
     const dw = outSize[0];

--- a/packages/circus-rs/src/server/ws/image-transfer-agent.ts
+++ b/packages/circus-rs/src/server/ws/image-transfer-agent.ts
@@ -216,7 +216,8 @@ const prepare = (
   // Maps a zero-based volume z-index to the corresponding image number,
   // The number is the number to be specified when call load() function.
   const zIndices = new Map<number, number>();
-
+  const imageNoToZ = (imageNo: number) =>
+    new MultiRange(images).toArray().indexOf(imageNo);
   if (partialVolumeDescriptor) {
     // Set zIndices for the partial volume.
     const partialImages = partialVolumeDescriptorToArray(
@@ -241,8 +242,10 @@ const prepare = (
     const imageNo = zIndices.get(zIndex);
     // console.log(`zIndex: ${zIndex} => #${imageNo}`);
     if (!imageNo) throw new Error('Invalid image request');
+    const z = imageNoToZ(imageNo);
+    if (z === -1) throw new Error('Invalid image request');
     await load(imageNo, priority ?? 0);
-    return volume.getSingleImage(imageNo - 1);
+    return volume.getSingleImage(z);
   };
 
   return { queue, fillImageToVolume };


### PR DESCRIPTION
Fixed display of 2D images whose pixel size is not 1 mm.
→ Modify image width and height of backContext.drawImage.

Fixed display of 3D images that are only partial slices saved.
→ Modify z-index (slice position in arrayBuffer).
