### PR TITLE
Modify error message pattern to fix broken test

### DIFF
--- a/packages/circus-api/src/utils/dockerFileExtractor.test.ts
+++ b/packages/circus-api/src/utils/dockerFileExtractor.test.ts
@@ -48,7 +48,7 @@ describe('extractToPath', () => {
     try {
       await expect(() =>
         extractor.extractToPath('/dummy-path', testDir)
-      ).rejects.toThrow(/No such container:path/);
+      ).rejects.toThrow(/No such container:path|Could not find the file/);
     } finally {
       extractor.dispose();
     }


### PR DESCRIPTION
This PR addresses the CI failure, which appears to be caused by a changed error message following an internal update of the Docker daemon.