### PR TITLE
Discard automatic retrieval of DOOD_HOST_WORKING_PATH

### DIFF
--- a/docker-build/Dockerfile
+++ b/docker-build/Dockerfile
@@ -101,7 +101,6 @@ ENV PATH=/circus:$PATH \
     LOCAL_HOST_IP=127.0.0.1 \
     DAEMON_MODE=0 \
     PM2_HOME=/circus/.pm2 \
-    MY_CONTAINER_ID=12345678 \
     DOOD_HOST_WORKING_PATH=/var/circus/data \
     AUTO_BOOT_JOB_MANAGER=0
 

--- a/docker-build/startup.sh
+++ b/docker-build/startup.sh
@@ -3,10 +3,6 @@
 # Set IP address of host machine
 LOCAL_HOST_IP=`getent hosts hostmachine | awk '{print $1}'`
 
-# Set doodHostWorkingDirectory option for pluginJobRunner
-MY_CONTAINER_ID=`basename "$(head /proc/1/cgroup)"`
-DOOD_HOST_WORKING_PATH=`docker inspect -f '{{json .Mounts }}' $MY_CONTAINER_ID | jq -r '.[] | select (.Destination == "/var/circus/data").Source'`
-
 if [ $DAEMON_MODE = 1 ]; then
   /circus/services.sh
 else


### PR DESCRIPTION
Corresponding to support cgroups v2, which is adopted in the new version of Ubuntu.