### PR TITLE
Integrate Version Checking into Existing Test Workflow and Automate NPM Publishing on Tag Push

### DIFF
--- a/.github/workflows/publish-npm-package.yml
+++ b/.github/workflows/publish-npm-package.yml
@@ -1,0 +1,31 @@
+name: Publish NPM Packages
+on:
+  push:
+    tags:
+      - '*'
+
+jobs:
+  build-and-publish:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
+        with:
+          node-version: 22.x
+          registry-url: 'https://registry.npmjs.org/'
+      - run: npm ci
+      - run: npm run build
+      - name: Publish
+        run: |
+          PACKAGES="circus-lib circus-icons circus-ui-kit circus-rs create-circus-cad-plugin"
+          for PACKAGE in $PACKAGES; do
+            cd packages/$PACKAGE
+            CURRENT_VERSION=$(npm info @utrad-ical/$PACKAGE version)
+            PACKAGE_VERSION=$(node -p "require('./package.json').version")
+            if [ "$PACKAGE_VERSION" \> "$CURRENT_VERSION" ]; then
+              npm publish --access public
+            fi
+            cd -
+          done
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -3,6 +3,46 @@ name: Test
 on: [push]
 
 jobs:
+  check-versions:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
+        with:
+          node-version: 22.x
+      - name: Log GITHUB_REF
+        run: echo "GITHUB_REF $GITHUB_REF"
+      - name: Check each package for changes and version updates
+        run: |
+          git fetch --tags
+          if [[ $GITHUB_REF == refs/tags/* ]]; then
+            LAST_TAG=$(git describe --tags --abbrev=0 HEAD^)
+          else
+            LAST_TAG=$(git describe --tags --abbrev=0 HEAD)
+          fi
+          echo "LAST_TAG determined: $LAST_TAG"
+          if [[ -z "$LAST_TAG" ]]; then
+            echo "No valid tag found for this push. Exiting..."
+            exit 0
+          fi
+          git fetch --depth=1 origin $LAST_TAG
+          CHANGED=false
+          for PACKAGE in circus-api circus-cs-core circus-icons circus-lib circus-rs circus-ui-kit circus-web-ui create-circus-cad-plugin; do
+            echo "Checking $PACKAGE..."
+            if git diff --name-only $LAST_TAG HEAD -- packages/$PACKAGE | grep -q ''; then
+              echo "$PACKAGE has changes since $LAST_TAG."
+              CURRENT_VERSION=$(node -p "require('./packages/$PACKAGE/package.json').version")
+              PREVIOUS_VERSION=$(git show $LAST_TAG:./packages/$PACKAGE/package.json | node -e "let data=''; process.stdin.on('data', chunk => data += chunk); process.stdin.on('end', () => console.log(JSON.parse(data).version));")
+              if [ "$CURRENT_VERSION" == "$PREVIOUS_VERSION" ]; then
+                echo "::error title=Package Version Not Updated::${PACKAGE} has changes but the version in package.json has not been updated."
+                CHANGED=true
+              fi
+            fi
+          done
+          if [ "$CHANGED" = true ]; then
+            exit 1
+          fi
+
   prettier-check:
     runs-on: ubuntu-latest
     env:


### PR DESCRIPTION
This PR enhances our existing CI process by integrating version checking into the 'Test' workflow that runs on every push, and automating NPM publishing when a tag is pushed.

**Version Checking:** As part of the existing 'Test' workflow, a new step has been added. If there are any changes between the current commit and the last tagged version, this step checks to see if the version in package.json is updated.
**NPM Publishing:** Automatically publishes the package to NPM when a tag is pushed.